### PR TITLE
Proposed code to limit number of resubmissions of a test

### DIFF
--- a/doc-sphinx/source/user_guide/adding_new_test.rst
+++ b/doc-sphinx/source/user_guide/adding_new_test.rst
@@ -92,6 +92,10 @@ application mentioned above:
     check_cmd = ./check_hello_mpi_c.sh 
     report_cmd = ./report_hello_mpi_c.sh
     resubmit = 0
+    # Use in conjunction with resubmit argument to limit total submissions/runs of a test (inclusive of initial run)
+    # Set to 0 for indefinite resubmissions
+    max_submissions = 3 
+
     
     #-- The following are user's defined and used for Key-Value replacements 
     nodes = 1
@@ -221,7 +225,7 @@ script for the *hello_mpi* application follows:
         0)
            echo "No resubmit";;
         1)
-           test_harness_driver.py -r;;
+           test_harness_driver.py -r __max_submissions__ ;;
     esac
 
 Using the job template above, the job will be submitted from the test *Scripts/*

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -88,7 +88,7 @@ def create_parser():
                            help='Use previously generated unique id')
     my_parser.add_argument('-r', '--resubmit',
                            help='Have the application test batch script resubmit itself, optionally for a total submission count of N. Leave off N for infinite submissions.',
-                           action='store', nargs='?', type=int, const=True, default=False)
+                           action='store', nargs='?', type=int, const=0, default=False)
     my_parser.add_argument('-R', '--run',
                            help='Run the application test batch script (NOTE: for use within a job)',
                            action='store_true')
@@ -308,19 +308,11 @@ def test_harness_driver(argv=None):
 
     do_resubmit = False
     if do_submit:
-        # No -r == None
-        # -r == True
-        # -r N == int(N)
-        #
-        # Only resubmit if -r N is > 1 
-        # -r is set
+        # Skip this logic if resubmit is not specified, or is set to 0 (indefinite resubmissions)
         if Vargs.resubmit:
-            # More than 1 iteration left, or no max was specified (infinite resubmissions). 
-            # Pass value from command line
-            if Vargs.resubmit > 1 or Vargs.resubmit is True:
+            if Vargs.resubmit > 1:
                 do_resubmit = Vargs.resubmit
             elif Vargs.resubmit <= 1:
-                # If -r N is <= 1, stop resubmissions
                 do_resubmit = False
                 do_submit = False
 

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -88,7 +88,7 @@ def create_parser():
                            help='Use previously generated unique id')
     my_parser.add_argument('-r', '--resubmit',
                            help='Have the application test batch script resubmit itself, optionally for a total submission count of N. Leave off N for infinite submissions.',
-                           action='store', nargs='?', type=int, const=0, default=False)
+                           action='store', nargs='?', type=int, const=-1, default=False)
     my_parser.add_argument('-R', '--run',
                            help='Run the application test batch script (NOTE: for use within a job)',
                            action='store_true')
@@ -309,7 +309,7 @@ def test_harness_driver(argv=None):
     do_resubmit = False
     if do_submit:
         # Skip this logic if resubmit is not specified, or is set to 0 (indefinite resubmissions)
-        if Vargs.resubmit:
+        if Vargs.resubmit and Vargs.resubmit != -1:
             if Vargs.resubmit > 1:
                 do_resubmit = Vargs.resubmit
             elif Vargs.resubmit <= 1:

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -188,10 +188,14 @@ def auto_generated_scripts(harness_config,
         # On further iterations, we'll take the count from `test_harness_driver.py -r  N` invocation, passed through actons['resubmit]
         #
         max_subs_cfg = mymachine.test_config.get_max_submissions() 
+        if max_subs_cfg is None:
+            # Ensure we have at least an empty string so the template variable can resolve
+            mymachine.test_config.set_max_submissions("")
+
         if actions['resubmit'] is 0 and max_subs_cfg is not False:
             # First iteration, decrement value from config. We have not invoked -r yet.
             max_subs_cfg = int(max_subs_cfg)
-            mymachine.test_config.set_max_submissions(str(max_subs_cfg-1))
+            mymachine.test_config.set_max_submissions(str(int(max_subs_cfg)-1))
         elif actions['resubmit'] and type(actions['resubmit']) == int:
             mymachine.test_config.set_max_submissions(str(actions['resubmit']-1))
 

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -87,8 +87,8 @@ def create_parser():
     my_parser.add_argument('-i', '--uniqueid',
                            help='Use previously generated unique id')
     my_parser.add_argument('-r', '--resubmit',
-                           help='Have the application test batch script resubmit itself',
-                           action='store_true')
+                           help='Have the application test batch script resubmit itself, optionally for a total submission count of N. Leave off N for infinite submissions.',
+                           action='store', nargs='?', type=int, const=True, default=False)
     my_parser.add_argument('-R', '--run',
                            help='Run the application test batch script (NOTE: for use within a job)',
                            action='store_true')
@@ -181,6 +181,20 @@ def auto_generated_scripts(harness_config,
         message = f"{messloc} No submit action due to prior failed build."
         a_logger.doCriticalLogging(message)
     elif actions['submit'] and (build_exit_value == 0):
+
+
+        # If we have specified a finite amount of submissions, override config
+        # On the first iteration, we'll have a value from the ini file that needs to be decremented here.
+        # On further iterations, we'll take the count from `test_harness_driver.py -r  N` invocation, passed through actons['resubmit]
+        #
+        max_subs_cfg = mymachine.test_config.get_max_submissions() 
+        if actions['resubmit'] is 0 and max_subs_cfg is not False:
+            # First iteration, decrement value from config. We have not invoked -r yet.
+            max_subs_cfg = int(max_subs_cfg)
+            mymachine.test_config.set_max_submissions(str(max_subs_cfg-1))
+        elif actions['resubmit'] and type(actions['resubmit']) == int:
+            mymachine.test_config.set_max_submissions(str(actions['resubmit']-1))
+
         # Create the batch script
         make_batch_script_status = mymachine.make_batch_script()
 
@@ -290,7 +304,22 @@ def test_harness_driver(argv=None):
 
     do_resubmit = False
     if do_submit:
-        do_resubmit = Vargs.resubmit
+        # No -r == None
+        # -r == True
+        # -r N == int(N)
+        #
+        # Only resubmit if -r N is > 1 
+        # -r is set
+        if Vargs.resubmit:
+            # More than 1 iteration left, or no max was specified (infinite resubmissions). 
+            # Pass value from command line
+            if Vargs.resubmit > 1 or Vargs.resubmit is True:
+                do_resubmit = Vargs.resubmit
+            elif Vargs.resubmit <= 1:
+                # If -r N is <= 1, stop resubmissions
+                do_resubmit = False
+                do_submit = False
+
 
     actions = {
         'build'    : do_build,
@@ -357,6 +386,7 @@ def test_harness_driver(argv=None):
             logging.shutdown()
             shutil.rmtree(runarchive_dir,ignore_errors=True)
             return
+
 
     # Create the status and run archive directories for this test instance
     status_dir = apptest.create_test_status()

--- a/harness/machine_types/rgt_test.py
+++ b/harness/machine_types/rgt_test.py
@@ -141,6 +141,7 @@ class RgtTest():
             "check_cmd": True,
             "executable_path" : False,
             "job_name" : True,
+            "max_submissions" : False,
             "nodes" : True,
             "processes_per_node" : False,
             "project_id" : False,
@@ -354,6 +355,12 @@ class RgtTest():
         return replacements
 
     #
+    # Convenience methods for setting specific parameters
+    #
+    def set_max_submissions(self, value):
+        self._set_builtin_param("max_submissions", value)
+
+    #
     # Convenience methods for retrieving specific parameters
     #
 
@@ -377,6 +384,9 @@ class RgtTest():
 
     def get_jobname(self):
         return self._get_builtin_param("job_name")
+
+    def get_max_submissions(self):
+        return self._get_builtin_param("max_submissions")
 
     def get_nodes(self):
         return self._get_builtin_param("nodes")
@@ -428,6 +438,9 @@ class RgtTest():
             sys.exit(err.message)
 
     # Private methods
+
+    def _set_builtin_param(self, key, value):
+        self.builtin_parameters[key] = value
 
     def _get_builtin_param(self, key):
         if key in self.builtin_parameters:


### PR DESCRIPTION
This is a proposal for a fairly simple way of implementing #10 . 

In short, this change adds an optional integer argument to the `--resubmit` option to `test_harness_driver.py` to limit further resubmissions. This variable is decremented each time a subsequent submission of the test is created and substituted into the job submission script. This could be used in addition to any further controls implemented by a dashboard or daemon.

* Propose thinking of this as "max submissions" rather than "max resubmissions". Prefer to think of this as inclusive of the initial submission so that if you want to "run 3 iterations of my test" you just specify 3. I thought it might be confusing if you had to specify the number of _re_submissions. This way seems more natural way of thinking.
* This looks to see if `-r N` has been specified, and will override the value from the config file. Unsure if this is hacky (especially the lack of a way to specify default values for optional parameters) but seems simpler than building a daemon or tracking .dot files.
* The `max_submissions` parameter can be omitted if `resubmit` is disabled. 
* The `max_submissions` parameter can be omitted or set to `0` if `resubmit` is enabled and you desire indefinite resubmissions.