### PR TITLE
Merge build stderr+stdout

### DIFF
--- a/harness/bin/runtests.py
+++ b/harness/bin/runtests.py
@@ -319,7 +319,7 @@ def create_parser():
                         action='store_true',
                         help="Use FireWorks to run harness tasks")
 
-    parser.add_argument("-sb", "--separate-build",
+    parser.add_argument("-sb", "--separate-build-stdio",
                         action='store_true',
                         required=False,
                         default=False,
@@ -356,7 +356,7 @@ def parse_commandline_argv(argv):
                                                               stdout_stderr=Vargs.output,
                                                               runmode=Vargs.mode,
                                                               use_fireworks=Vargs.fireworks,
-                                                              separate_build=Vargs.separate_build)
+                                                              separate_build_stdio=Vargs.separate_build_stdio)
     return harness_parsed_args
 
 def runtests(my_arg_string=None):
@@ -410,7 +410,7 @@ def runtests(my_arg_string=None):
                                   harness_arguments.loglevel,
                                   harness_arguments.stdout_stderr,
                                   harness_arguments.use_fireworks,
-                                  harness_arguments.separate_build)
+                                  harness_arguments.separate_build_stdio)
 
     main_logger.info("Created an instance of the harness.")
     main_logger.info("Harness: " + str(rgt))

--- a/harness/bin/runtests.py
+++ b/harness/bin/runtests.py
@@ -319,6 +319,12 @@ def create_parser():
                         action='store_true',
                         help="Use FireWorks to run harness tasks")
 
+    parser.add_argument("-sb", "--separate-build",
+                        action='store_true',
+                        required=False,
+                        default=False,
+                        help="Separate output from build into build_out.stderr.txt and build_out.stdout.txt")
+
     return parser
 
 def parse_commandline_argv(argv):
@@ -349,7 +355,8 @@ def parse_commandline_argv(argv):
                                                               configfile=Vargs.configfile,
                                                               stdout_stderr=Vargs.output,
                                                               runmode=Vargs.mode,
-                                                              use_fireworks=Vargs.fireworks)
+                                                              use_fireworks=Vargs.fireworks,
+                                                              separate_build=Vargs.separate_build)
     return harness_parsed_args
 
 def runtests(my_arg_string=None):
@@ -402,7 +409,8 @@ def runtests(my_arg_string=None):
     rgt = regression_test.Harness(config, ifile,
                                   harness_arguments.loglevel,
                                   harness_arguments.stdout_stderr,
-                                  harness_arguments.use_fireworks)
+                                  harness_arguments.use_fireworks,
+                                  harness_arguments.separate_build)
 
     main_logger.info("Created an instance of the harness.")
     main_logger.info("Harness: " + str(rgt))

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -73,6 +73,9 @@ def create_parser():
     my_parser.add_argument('-b', '--build',
                            help='Build the application test',
                            action='store_true')
+    my_parser.add_argument('-sb', '--separate-build',
+                           help='Separate the stdout and stderr of a build',
+                           action='store_true')
     my_parser.add_argument('-c', '--check',
                            help='Check the application test results',
                            action='store_true')
@@ -137,7 +140,8 @@ def auto_generated_scripts(harness_config,
                            apptest,
                            jstatus,
                            actions,
-                           a_logger):
+                           a_logger,
+                           separate_build=False):
     """
     Generates and executes scripts to build, run, and check a test.
 
@@ -151,7 +155,7 @@ def auto_generated_scripts(harness_config,
     ra_dir = apptest.get_path_to_runarchive()
 
     # Instantiate the machine for this computer.
-    mymachine = MachineFactory.create_machine(harness_config, apptest)
+    mymachine = MachineFactory.create_machine(harness_config, apptest, separate_build=separate_build)
 
     #-----------------------------------------------------
     # In this section we build the binary.               -
@@ -410,7 +414,8 @@ def test_harness_driver(argv=None):
                                              apptest,
                                              jstatus,
                                              actions,
-                                             a_logger)
+                                             a_logger,
+                                             Vargs.separate_build)
     else:
         error_message = "The user generated scripts functionality is no longer supported"
         a_logger.doCriticalLogging(error_message)

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -73,7 +73,7 @@ def create_parser():
     my_parser.add_argument('-b', '--build',
                            help='Build the application test',
                            action='store_true')
-    my_parser.add_argument('-sb', '--separate-build',
+    my_parser.add_argument('-sb', '--separate-build-stdio',
                            help='Separate the stdout and stderr of a build',
                            action='store_true')
     my_parser.add_argument('-c', '--check',
@@ -141,7 +141,7 @@ def auto_generated_scripts(harness_config,
                            jstatus,
                            actions,
                            a_logger,
-                           separate_build=False):
+                           separate_build_stdio=False):
     """
     Generates and executes scripts to build, run, and check a test.
 
@@ -155,7 +155,7 @@ def auto_generated_scripts(harness_config,
     ra_dir = apptest.get_path_to_runarchive()
 
     # Instantiate the machine for this computer.
-    mymachine = MachineFactory.create_machine(harness_config, apptest, separate_build=separate_build)
+    mymachine = MachineFactory.create_machine(harness_config, apptest, separate_build_stdio=separate_build_stdio)
 
     #-----------------------------------------------------
     # In this section we build the binary.               -
@@ -415,7 +415,7 @@ def test_harness_driver(argv=None):
                                              jstatus,
                                              actions,
                                              a_logger,
-                                             Vargs.separate_build)
+                                             Vargs.separate_build_stdio)
     else:
         error_message = "The user generated scripts functionality is no longer supported"
         a_logger.doCriticalLogging(error_message)

--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -101,7 +101,7 @@ class subtest(base_apptest, apptest_layout):
                 test_checkout_lock=None,
                 test_display_lock=None,
                 stdout_stderr=None,
-                separate_build=False):
+                separate_build_stdio=False):
         """
         :param list_of_string my_tasks: A list of the strings
                                         where each element is an application
@@ -153,7 +153,7 @@ class subtest(base_apptest, apptest_layout):
                 message = "Start of starting test."
                 self.doInfoLogging(message)
 
-                self._start_test(stdout_stderr, separate_build=separate_build)
+                self._start_test(stdout_stderr, separate_build_stdio=separate_build_stdio)
 
                 message = "End of starting test"
                 self.doInfoLogging(message)
@@ -508,7 +508,7 @@ class subtest(base_apptest, apptest_layout):
     #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     def _start_test(self,
                     stdout_stderr,
-                    separate_build=False):
+                    separate_build_stdio=False):
 
         # If the file kill file exits then remove it.
         pathtokillfile = self.get_path_to_kill_file()
@@ -516,8 +516,8 @@ class subtest(base_apptest, apptest_layout):
             os.remove(pathtokillfile)
 
         # This will automatically build & submit
-        if separate_build:
-            starttestcomand = "test_harness_driver.py -r --separate-build"
+        if separate_build_stdio:
+            starttestcomand = "test_harness_driver.py -r --separate-build-stdio"
         else:
             starttestcomand = "test_harness_driver.py -r"
 
@@ -582,13 +582,13 @@ class ApptestImproperInstantiationError(BaseApptestError):
 def do_application_tasks(app_test_list,
                          tasks,
                          stdout_stderr,
-                         separate_build=False):
+                         separate_build_stdio=False):
     print(f"App_test_list: {app_test_list}")
     print(f"Tasks: {tasks}")
     for app_test in app_test_list:
         app_test.doTasks(tasks=tasks,
                          stdout_stderr=stdout_stderr,
-                         separate_build=separate_build)
+                         separate_build_stdio=separate_build_stdio)
     return
 
 def wait_for_jobs_to_complete_in_queue(harness_config,

--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -100,7 +100,8 @@ class subtest(base_apptest, apptest_layout):
                 tasks=None,
                 test_checkout_lock=None,
                 test_display_lock=None,
-                stdout_stderr=None):
+                stdout_stderr=None,
+                separate_build=False):
         """
         :param list_of_string my_tasks: A list of the strings
                                         where each element is an application
@@ -152,7 +153,7 @@ class subtest(base_apptest, apptest_layout):
                 message = "Start of starting test."
                 self.doInfoLogging(message)
 
-                self._start_test(stdout_stderr)
+                self._start_test(stdout_stderr, separate_build=separate_build)
 
                 message = "End of starting test"
                 self.doInfoLogging(message)
@@ -506,14 +507,19 @@ class subtest(base_apptest, apptest_layout):
     #                                                                 @
     #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     def _start_test(self,
-                    stdout_stderr):
+                    stdout_stderr,
+                    separate_build=False):
 
         # If the file kill file exits then remove it.
         pathtokillfile = self.get_path_to_kill_file()
         if os.path.lexists(pathtokillfile):
             os.remove(pathtokillfile)
 
-        starttestcomand = "test_harness_driver.py -r"
+        # This will automatically build & submit
+        if separate_build:
+            starttestcomand = "test_harness_driver.py -r --separate-build"
+        else:
+            starttestcomand = "test_harness_driver.py -r"
 
         pathtoscripts = self.get_path_to_scripts()
 
@@ -575,10 +581,14 @@ class ApptestImproperInstantiationError(BaseApptestError):
 
 def do_application_tasks(app_test_list,
                          tasks,
-                         stdout_stderr):
+                         stdout_stderr,
+                         separate_build=False):
+    print(f"App_test_list: {app_test_list}")
+    print(f"Tasks: {tasks}")
     for app_test in app_test_list:
         app_test.doTasks(tasks=tasks,
-                         stdout_stderr=stdout_stderr)
+                         stdout_stderr=stdout_stderr,
+                         separate_build=separate_build)
     return
 
 def wait_for_jobs_to_complete_in_queue(harness_config,

--- a/harness/libraries/command_line.py
+++ b/harness/libraries/command_line.py
@@ -15,7 +15,7 @@ class HarnessParsedArguments:
                        runmode=None,
                        stdout_stderr=None,
                        use_fireworks=False,
-                       separate_build=False):
+                       separate_build_stdio=False):
 
         self.__inputfile = inputfile
         self.__loglevel = loglevel
@@ -23,7 +23,7 @@ class HarnessParsedArguments:
         self.__mode = runmode
         self.__stdout_stderr = stdout_stderr
         self.__use_fireworks = use_fireworks
-        self.__separate_build = separate_build
+        self.__separate_build_stdio = separate_build_stdio
 
         self.__verify_attributes()
 
@@ -65,8 +65,8 @@ class HarnessParsedArguments:
         return self.__use_fireworks
 
     @property
-    def separate_build(self):
-        return self.__separate_build
+    def separate_build_stdio(self):
+        return self.__separate_build_stdio
 
     @property
     def effective_command_line(self):
@@ -76,6 +76,7 @@ class HarnessParsedArguments:
                            " --configfile {my_configfile}"
                            " --loglevel {my_loglevel}"
                            " --output {my_output}"
+                           " --separate-build-stdio"
                            " --mode {my_runmode}")
 
         run_mode_args=" ".join(self.runmode) 

--- a/harness/libraries/command_line.py
+++ b/harness/libraries/command_line.py
@@ -14,7 +14,8 @@ class HarnessParsedArguments:
                        configfile=None,
                        runmode=None,
                        stdout_stderr=None,
-                       use_fireworks=False):
+                       use_fireworks=False,
+                       separate_build=False):
 
         self.__inputfile = inputfile
         self.__loglevel = loglevel
@@ -22,6 +23,7 @@ class HarnessParsedArguments:
         self.__mode = runmode
         self.__stdout_stderr = stdout_stderr
         self.__use_fireworks = use_fireworks
+        self.__separate_build = separate_build
 
         self.__verify_attributes()
 
@@ -61,6 +63,10 @@ class HarnessParsedArguments:
     @property
     def use_fireworks(self):
         return self.__use_fireworks
+
+    @property
+    def separate_build(self):
+        return self.__separate_build
 
     @property
     def effective_command_line(self):

--- a/harness/libraries/regression_test.py
+++ b/harness/libraries/regression_test.py
@@ -44,7 +44,7 @@ class Harness:
                  log_level,
                  stdout_stderr,
                  use_fireworks,
-                 separate_build):
+                 separate_build_stdio):
         self.__config = config
         self.__tests = rgt_input_file.get_tests()
         self.__tasks = rgt_input_file.get_harness_tasks()
@@ -56,7 +56,7 @@ class Harness:
         self.__stdout_stderr = stdout_stderr
         self.__num_workers = 1
         self.__use_fireworks = use_fireworks
-        self.__separate_build = separate_build
+        self.__separate_build_stdio = separate_build_stdio
         self.__formAppTests()
 
         currenttime = time.localtime()
@@ -247,7 +247,7 @@ class Harness:
                                          self.__app_subtests[appname],
                                          self.__tasks,
                                          self.__stdout_stderr,
-                                         self.__separate_build)
+                                         self.__separate_build_stdio)
                 future_to_appname[future] = appname
 
             # Log when all job tasks are initiated.
@@ -300,8 +300,8 @@ class Harness:
 
                 # create build FireWork
                 taskname = f'OTH-BLD.{machine_name}.{task_suffix}'
-                if self.__separate_build:
-                    driver_cmd = f'test_harness_driver.py -C {cfg_file} --build --separate-build --scriptsdir {scripts_dir} --uniqueid {uid}'
+                if self.__separate_build_stdio:
+                    driver_cmd = f'test_harness_driver.py -C {cfg_file} --build --separate-build-stdio --scriptsdir {scripts_dir} --uniqueid {uid}'
                 else:
                     driver_cmd = f'test_harness_driver.py -C {cfg_file} --build --scriptsdir {scripts_dir} --uniqueid {uid}'
                 script_cmd = f'echo "Running: {driver_cmd}"; {driver_cmd} &> fwbuild.log'

--- a/harness/libraries/regression_test.py
+++ b/harness/libraries/regression_test.py
@@ -43,7 +43,8 @@ class Harness:
                  rgt_input_file,
                  log_level,
                  stdout_stderr,
-                 use_fireworks):
+                 use_fireworks,
+                 separate_build):
         self.__config = config
         self.__tests = rgt_input_file.get_tests()
         self.__tasks = rgt_input_file.get_harness_tasks()
@@ -55,6 +56,7 @@ class Harness:
         self.__stdout_stderr = stdout_stderr
         self.__num_workers = 1
         self.__use_fireworks = use_fireworks
+        self.__separate_build = separate_build
         self.__formAppTests()
 
         currenttime = time.localtime()
@@ -244,7 +246,8 @@ class Harness:
                 future = executor.submit(apptest.do_application_tasks,
                                          self.__app_subtests[appname],
                                          self.__tasks,
-                                         self.__stdout_stderr)
+                                         self.__stdout_stderr,
+                                         self.__separate_build)
                 future_to_appname[future] = appname
 
             # Log when all job tasks are initiated.
@@ -297,7 +300,10 @@ class Harness:
 
                 # create build FireWork
                 taskname = f'OTH-BLD.{machine_name}.{task_suffix}'
-                driver_cmd = f'test_harness_driver.py -C {cfg_file} --build --scriptsdir {scripts_dir} --uniqueid {uid}'
+                if self.__separate_build:
+                    driver_cmd = f'test_harness_driver.py -C {cfg_file} --build --separate-build --scriptsdir {scripts_dir} --uniqueid {uid}'
+                else:
+                    driver_cmd = f'test_harness_driver.py -C {cfg_file} --build --scriptsdir {scripts_dir} --uniqueid {uid}'
                 script_cmd = f'echo "Running: {driver_cmd}"; {driver_cmd} &> fwbuild.log'
                 build_task = ScriptTask(script=script_cmd,
                                         store_stdout=True, store_stderr=True)

--- a/harness/machine_types/base_machine.py
+++ b/harness/machine_types/base_machine.py
@@ -46,7 +46,7 @@ class BaseMachine(metaclass=ABCMeta):
     # The constructor of class base_machine.
     def __init__(self, name, scheduler_type, jobLauncher_type,
                  numNodes, numSockets, numCoresPerSocket,
-                 apptest):
+                 apptest, separate_build=False):
 
         self.__name = name
 
@@ -59,6 +59,7 @@ class BaseMachine(metaclass=ABCMeta):
         self.__numSockets = numSockets
         self.__numCoresPerSocket = numCoresPerSocket
         self.__apptest = apptest
+        self.__separate_build = separate_build
 
         runarchive_dir = self.apptest.get_path_to_runarchive()
         log_filepath = os.path.join(runarchive_dir,self.__class__.__module__)
@@ -92,6 +93,11 @@ class BaseMachine(metaclass=ABCMeta):
     def machine_name(self):
         """str: The name of the machine."""
         return self.__name
+
+    @property
+    def separate_build(self):
+        """bool: If true, separate build into stdout and stderr"""
+        return self.__separate_build
 
     @property
     def check_command(self):

--- a/harness/machine_types/base_machine.py
+++ b/harness/machine_types/base_machine.py
@@ -46,7 +46,7 @@ class BaseMachine(metaclass=ABCMeta):
     # The constructor of class base_machine.
     def __init__(self, name, scheduler_type, jobLauncher_type,
                  numNodes, numSockets, numCoresPerSocket,
-                 apptest, separate_build=False):
+                 apptest, separate_build_stdio=False):
 
         self.__name = name
 
@@ -59,7 +59,7 @@ class BaseMachine(metaclass=ABCMeta):
         self.__numSockets = numSockets
         self.__numCoresPerSocket = numCoresPerSocket
         self.__apptest = apptest
-        self.__separate_build = separate_build
+        self.__separate_build_stdio = separate_build_stdio
 
         runarchive_dir = self.apptest.get_path_to_runarchive()
         log_filepath = os.path.join(runarchive_dir,self.__class__.__module__)
@@ -95,9 +95,9 @@ class BaseMachine(metaclass=ABCMeta):
         return self.__name
 
     @property
-    def separate_build(self):
+    def separate_build_stdio(self):
         """bool: If true, separate build into stdout and stderr"""
-        return self.__separate_build
+        return self.__separate_build_stdio
 
     @property
     def check_command(self):

--- a/harness/machine_types/ibm_power9.py
+++ b/harness/machine_types/ibm_power9.py
@@ -25,7 +25,7 @@ class IBMpower9(BaseMachine):
                  numCoresPerSocket=21,
                  rgt_test_input_file=None,
                  apptest=None,
-                 separate_build=False):
+                 separate_build_stdio=False):
 
         BaseMachine.__init__(self,
                              name=name,
@@ -35,7 +35,7 @@ class IBMpower9(BaseMachine):
                              numSockets = numSocketsPerNode,
                              numCoresPerSocket = numCoresPerSocket,
                              apptest=apptest,
-                             separate_build=separate_build)
+                             separate_build_stdio=separate_build_stdio)
 
         # process test input file. The subtest knows the path to the 
         # the test input file.

--- a/harness/machine_types/ibm_power9.py
+++ b/harness/machine_types/ibm_power9.py
@@ -24,7 +24,8 @@ class IBMpower9(BaseMachine):
                  numSocketsPerNode=2,
                  numCoresPerSocket=21,
                  rgt_test_input_file=None,
-                 apptest=None):
+                 apptest=None,
+                 separate_build=False):
 
         BaseMachine.__init__(self,
                              name=name,
@@ -33,7 +34,8 @@ class IBMpower9(BaseMachine):
                              numNodes = numNodes,
                              numSockets = numSocketsPerNode,
                              numCoresPerSocket = numCoresPerSocket,
-                             apptest=apptest)
+                             apptest=apptest,
+                             separate_build=separate_build)
 
         # process test input file. The subtest knows the path to the 
         # the test input file.

--- a/harness/machine_types/linux_utilities.py
+++ b/harness/machine_types/linux_utilities.py
@@ -409,7 +409,7 @@ def build_executable(a_machine, new_env):
     message = f"{messloc} The build command: {buildcmd}"
     a_machine.logger.doInfoLogging(message)
 
-    if a_machine.separate_build:
+    if a_machine.separate_build_stdio:
         build_std_out = "output_build.stdout.txt"
         build_std_err = "output_build.stderr.txt"
         with open(build_std_out,"w") as build_std_out :

--- a/harness/machine_types/linux_utilities.py
+++ b/harness/machine_types/linux_utilities.py
@@ -406,14 +406,21 @@ def build_executable(a_machine, new_env):
 
     # We get the command for bulding the binary.
     buildcmd = a_machine.test_config.get_build_command()
-    build_std_out = "output_build.stdout.txt"
-    build_std_err = "output_build.stderr.txt"
     message = f"{messloc} The build command: {buildcmd}"
     a_machine.logger.doInfoLogging(message)
 
-    with open(build_std_out,"w") as build_std_out :
-        with open(build_std_err,"w") as build_std_err :
-            p = subprocess.Popen(buildcmd, shell=True, stdout=build_std_out, stderr=build_std_err)
+    if a_machine.separate_build:
+        build_std_out = "output_build.stdout.txt"
+        build_std_err = "output_build.stderr.txt"
+        with open(build_std_out,"w") as build_std_out :
+            with open(build_std_err,"w") as build_std_err :
+                p = subprocess.Popen(buildcmd, shell=True, stdout=build_std_out, stderr=build_std_err)
+                p.wait()
+                build_exit_status = p.returncode
+    else:
+        build_out = "output_build.txt"
+        with open(build_out,"w") as build_out :
+            p = subprocess.Popen(buildcmd, shell=True, stdout=build_out, stderr=subprocess.STDOUT)
             p.wait()
             build_exit_status = p.returncode
 

--- a/harness/machine_types/linux_x86_64.py
+++ b/harness/machine_types/linux_x86_64.py
@@ -25,7 +25,7 @@ class Linux_x86_64(BaseMachine):
                  numCoresPerSocket=1,
                  rgt_test_input_file=None,
                  apptest=None,
-                 separate_build=False):
+                 separate_build_stdio=False):
 
         BaseMachine.__init__(self,
                              name=name,
@@ -35,7 +35,7 @@ class Linux_x86_64(BaseMachine):
                              numSockets=numSocketsPerNode,
                              numCoresPerSocket=numCoresPerSocket,
                              apptest=apptest,
-                             separate_build=separate_build)
+                             separate_build_stdio=separate_build_stdio)
 
         # process test input file. The subtest knows the path to the
         # the test input file.

--- a/harness/machine_types/linux_x86_64.py
+++ b/harness/machine_types/linux_x86_64.py
@@ -24,7 +24,8 @@ class Linux_x86_64(BaseMachine):
                  numSocketsPerNode=1,
                  numCoresPerSocket=1,
                  rgt_test_input_file=None,
-                 apptest=None):
+                 apptest=None,
+                 separate_build=False):
 
         BaseMachine.__init__(self,
                              name=name,
@@ -33,7 +34,8 @@ class Linux_x86_64(BaseMachine):
                              numNodes=numNodes,
                              numSockets=numSocketsPerNode,
                              numCoresPerSocket=numCoresPerSocket,
-                             apptest=apptest)
+                             apptest=apptest,
+                             separate_build=separate_build)
 
         # process test input file. The subtest knows the path to the
         # the test input file.

--- a/harness/machine_types/machine_factory.py
+++ b/harness/machine_types/machine_factory.py
@@ -16,7 +16,7 @@ class MachineFactory:
     @staticmethod
     def create_machine(harness_config,
                        app_subtest,
-                       separate_build=False):
+                       separate_build_stdio=False):
 
         machine_config = harness_config.get_machine_config()
 
@@ -80,7 +80,7 @@ class MachineFactory:
                                         numNodes=int(rgt_num_nodes),
                                         numSocketsPerNode=int(rgt_sockets_per_node),
                                         numCoresPerSocket=int(rgt_cores_per_socket),
-                                        separate_build=separate_build,
+                                        separate_build_stdio=separate_build_stdio,
                                         apptest=app_subtest)
             elif rgt_machine_type == "linux_x86_64":
                 tmp_machine = Linux_x86_64(name=rgt_machine_name,
@@ -89,7 +89,7 @@ class MachineFactory:
                                            numNodes=int(rgt_num_nodes),
                                            numSocketsPerNode=int(rgt_sockets_per_node),
                                            numCoresPerSocket=int(rgt_cores_per_socket),
-                                           separate_build=separate_build,
+                                           separate_build_stdio=separate_build_stdio,
                                            apptest=app_subtest)
             else:
                 raise MachineTypeNotImplementedError(rgt_machine_type)

--- a/harness/machine_types/machine_factory.py
+++ b/harness/machine_types/machine_factory.py
@@ -15,7 +15,8 @@ class MachineFactory:
 
     @staticmethod
     def create_machine(harness_config,
-                       app_subtest):
+                       app_subtest,
+                       separate_build=False):
 
         machine_config = harness_config.get_machine_config()
 
@@ -79,6 +80,7 @@ class MachineFactory:
                                         numNodes=int(rgt_num_nodes),
                                         numSocketsPerNode=int(rgt_sockets_per_node),
                                         numCoresPerSocket=int(rgt_cores_per_socket),
+                                        separate_build=separate_build,
                                         apptest=app_subtest)
             elif rgt_machine_type == "linux_x86_64":
                 tmp_machine = Linux_x86_64(name=rgt_machine_name,
@@ -87,6 +89,7 @@ class MachineFactory:
                                            numNodes=int(rgt_num_nodes),
                                            numSocketsPerNode=int(rgt_sockets_per_node),
                                            numCoresPerSocket=int(rgt_cores_per_socket),
+                                           separate_build=separate_build,
                                            apptest=app_subtest)
             else:
                 raise MachineTypeNotImplementedError(rgt_machine_type)


### PR DESCRIPTION
Implemented code to merge build stderr+stdout by default. Allowed `--separate-build` command line flag to run-tests.py and test_harness_driver.py to separate the build into stderr and stdout files.