### PR TITLE
Add launch id and run count to test status file

### DIFF
--- a/harness/bin/log_binary_execution_time.py
+++ b/harness/bin/log_binary_execution_time.py
@@ -24,12 +24,11 @@ def create_a_parser():
                                                   status execution log file.",
                                      add_help=True)
         
-    parser.add_argument("--scriptsdir", nargs=1, required=True,
+    parser.add_argument("--scriptsdir", type=str, required=True,
                         help="The location of the test scripts directory. Must be an absolute path.")
     
-    parser.add_argument("--uniqueid", nargs=1, required=True,
+    parser.add_argument("--uniqueid", type=str, required=True,
                         help="The unique id of the test.")
-    
 
     parser.add_argument("--mode", required=True, nargs=1, choices=["start","final"],
                         help="Used to decide to where log the current time the start or final execution log file")
@@ -45,8 +44,8 @@ def main():
     Vargs = parser.parse_args()
 
     log_mode = str(Vargs.mode[0])
-    unique_id = Vargs.uniqueid[0]
-    scriptsdir = Vargs.scriptsdir[0]
+    unique_id = Vargs.uniqueid
+    scriptsdir = Vargs.scriptsdir
 
     # Change to the scripts directory of the test
     cwd = os.getcwd()
@@ -61,7 +60,7 @@ def main():
                                           tag=unique_id)
     path_to_status_file = apptest.get_path_to_status_file()
     jstatus = StatusFileFactory.create(path_to_status_file=path_to_status_file)
-    jstatus.initialize_subtest(unique_id)
+    jstatus.initialize_subtest(None, unique_id)
 
     # Log the appropriate event to the status file
     if log_mode == "start":

--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -97,6 +97,7 @@ class subtest(base_apptest, apptest_layout):
         return self.__myLogger
 
     def doTasks(self,
+                launchid=None,
                 tasks=None,
                 test_checkout_lock=None,
                 test_display_lock=None,
@@ -153,7 +154,7 @@ class subtest(base_apptest, apptest_layout):
                 message = "Start of starting test."
                 self.doInfoLogging(message)
 
-                self._start_test(stdout_stderr, separate_build_stdio=separate_build_stdio)
+                self._start_test(launchid, stdout_stderr, separate_build_stdio=separate_build_stdio)
 
                 message = "End of starting test"
                 self.doInfoLogging(message)
@@ -507,6 +508,7 @@ class subtest(base_apptest, apptest_layout):
     #                                                                 @
     #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     def _start_test(self,
+                    launchid,
                     stdout_stderr,
                     separate_build_stdio=False):
 
@@ -516,10 +518,9 @@ class subtest(base_apptest, apptest_layout):
             os.remove(pathtokillfile)
 
         # This will automatically build & submit
+        starttestcomand = f"test_harness_driver.py -r -l {launchid}"
         if separate_build_stdio:
-            starttestcomand = "test_harness_driver.py -r --separate-build-stdio"
-        else:
-            starttestcomand = "test_harness_driver.py -r"
+            starttestcomand += "--separate-build-stdio"
 
         pathtoscripts = self.get_path_to_scripts()
 
@@ -579,13 +580,15 @@ class ApptestImproperInstantiationError(BaseApptestError):
     def message(self):
         return self.__message
 
-def do_application_tasks(app_test_list,
+def do_application_tasks(launch_id,
+                         app_test_list,
                          tasks,
                          stdout_stderr,
                          separate_build_stdio=False):
     for app_test in app_test_list:
         print(f"Starting tasks for Application.Test: {app_test.getNameOfApplication()}.{app_test.getNameOfSubtest()}")
-        app_test.doTasks(tasks=tasks,
+        app_test.doTasks(launchid=launch_id,
+                         tasks=tasks,
                          stdout_stderr=stdout_stderr,
                          separate_build_stdio=separate_build_stdio)
     return

--- a/harness/machine_types/rgt_test.py
+++ b/harness/machine_types/rgt_test.py
@@ -141,6 +141,7 @@ class RgtTest():
             "check_cmd": True,
             "executable_path" : False,
             "job_name" : True,
+            "launch_id" : False,
             "max_submissions" : False,
             "nodes" : True,
             "processes_per_node" : False,
@@ -357,6 +358,9 @@ class RgtTest():
     #
     # Convenience methods for setting specific parameters
     #
+    def set_launch_id(self, value):
+        self._set_builtin_param("launch_id", value)
+
     def set_max_submissions(self, value):
         self._set_builtin_param("max_submissions", value)
 
@@ -384,6 +388,9 @@ class RgtTest():
 
     def get_jobname(self):
         return self._get_builtin_param("job_name")
+
+    def get_launch_id(self):
+        return self._get_builtin_param("launch_id")
 
     def get_max_submissions(self):
         return self._get_builtin_param("max_submissions")


### PR DESCRIPTION
Addresses Issue #16 

Adds two new columns to the `<app>/<test>/Status/rgt_status.txt` files, 'Launch ID' and 'Run Count', to help track resubmissions. The launch id is a timestamp from when `runtests.py` was invoked. The run count is a ratio given as `submit_count/max_submissions`

To take advantage of the new resubmission tracking capability, the test's job script epilog should be updated to use:
`test_harness_driver.py -l __launch_id__ -r __max_submissions__`