### PR TITLE
Add return code check around job ID output parser

### DIFF
--- a/harness/machine_types/slurm.py
+++ b/harness/machine_types/slurm.py
@@ -64,16 +64,11 @@ class SLURM(BaseScheduler):
         records = submit_stdout.readlines()
         submit_stdout.close()
 
-        #print("records = ")
-        #print(records)
-        #print("Extracting SLURM jobID from SLURM class")
-        jobid_pattern = re.compile('\d+')
-        #print("jobid_pattern = ")
-        #print(jobid_pattern)
-        #print("jobid_pattern.findall = ")
-        jobid = jobid_pattern.findall(records[0])[0]
-        self.set_job_id(jobid)
-        print("SLURM jobID = ",self.get_job_id())
+        if p.returncode is 0:
+            jobid_pattern = re.compile('\d+')
+            jobid = jobid_pattern.findall(records[0])[0]
+            self.set_job_id(jobid)
+            print("SLURM jobID = ",self.get_job_id())
 
         return p.returncode
 


### PR DESCRIPTION
Otherwise the job ID parser will unsuccessfully attempt to parse error messages for the job ID.

Addresses #23 