### PR TITLE
Fix issue 29 by using default branch instead of "master"

### DIFF
--- a/harness/libraries/repositories/git_repository.py
+++ b/harness/libraries/repositories/git_repository.py
@@ -13,7 +13,7 @@ class GitRepository(BaseRepository):
     """
     def __init__(self,
                  git_remote_repository_url=None,
-                 my_repository_branch="master") :
+                 my_repository_branch="default") :
 
         
         self.binaryName = "git"
@@ -51,9 +51,13 @@ class GitRepository(BaseRepository):
     def cloneRepository(self,
                         destination_directory="."):
 
-        my_clone_command="{gitbinary} clone --branch {branch} --recurse-submodules {repository} {directory}".format(
+        clone_branch = ""
+        if self.repository_branch != "default":
+            clone_branch = f'--branch {self.repository_branch}'
+
+        my_clone_command="{gitbinary} clone {branch} --recurse-submodules {repository} {directory}".format(
                   gitbinary=self.binaryName,
-                  branch=self.repository_branch, 
+                  branch=clone_branch,
                   repository=self.remote_repository_URL,
                   directory=destination_directory)
 

--- a/harness/libraries/repositories/repository_factory.py
+++ b/harness/libraries/repositories/repository_factory.py
@@ -109,7 +109,9 @@ class RepositoryFactory:
 
     @classmethod
     def get_repository_git_branch(cls):
-        my_git_branch=os.getenv("RGT_GIT_REPS_BRANCH")
+        my_git_branch = os.getenv("RGT_GIT_REPS_BRANCH")
+        if my_git_branch is None:
+            my_git_branch = "default"
         return my_git_branch
 
 

--- a/harness/libraries/repositories/single_app_git_repository.py
+++ b/harness/libraries/repositories/single_app_git_repository.py
@@ -69,7 +69,7 @@ class SingleApplicationGitRepository(BaseRepository):
 
     def __init__(self,
                  git_remote_repository_url=None,
-                 my_repository_branch="master") :
+                 my_repository_branch="default") :
 
         
         self.binaryName = "git"
@@ -109,9 +109,13 @@ class SingleApplicationGitRepository(BaseRepository):
                         logger=None):
 
 
-        my_clone_command="{gitbinary} clone --branch {branch} --recurse-submodules {repository}".format(
+        clone_branch = ""
+        if self.repository_branch != "default":
+            clone_branch = f'--branch {self.repository_branch}'
+
+        my_clone_command="{gitbinary} clone {branch} --recurse-submodules {repository}".format(
                   gitbinary=self.binaryName,
-                  branch=self.repository_branch, 
+                  branch=clone_branch,
                   repository=self.remote_repository_URL)
 
         basename = os.path.basename(self.remote_repository_URL)


### PR DESCRIPTION
This PR fixes issue #29 by omitting the `--branch <branchname>` argument to the `git clone` command used for repo checkouts when the environment variable `RGT_GIT_REPS_BRANCH` is not set.

Note that the machine config files have a `[RepoDetails].git_reps_branch` setting that will cause the environment variable to be set to the given value. To allow checkout of the default branch for each app repo, you should remove the setting from your machine config file, or use the value "default".