### PR TITLE
Added logic gate to creation of .influx_logged

### DIFF
--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -823,7 +823,8 @@ class subtest(base_apptest, apptest_layout):
 
         # We're in Run_Archive. The Influx POST request has succeeded, as far as we know,
         # so let's create a .influx_logged file
-        os.mknod('.influx_logged')
+        if failed_log_attempts == 0 and success_log_attempts > 0:
+            os.mknod('.influx_logged')
 
         os.chdir(currentdir)
         # If >0 records have been sent, and no failed attempts, return True


### PR DESCRIPTION
Control flow of the function changed with the latest PRs, so even failed logging attempts will still reach this part of the code, and a logic gate is now required