### PR TITLE
Updated nm_iters functionality in the rgt.input file

### DIFF
--- a/harness/libraries/input_files.py
+++ b/harness/libraries/input_files.py
@@ -106,10 +106,13 @@ class rgt_input_file:
                 # by the last word.
                 app = words[2]
                 subtest = words[3]
-                nm_iters = -1
                 if len(words) == 5:
                     nm_iters = int(words[4])
-                self.__tests.append([app,subtest,nm_iters])
+                    # Add nm_iters parallel copies of the same test
+                    for i in range(0, nm_iters):
+                        self.__tests.append([app,subtest])
+                else:
+                    self.__tests.append([app,subtest])
 
             elif firstword == rgt_input_file.path_to_test_entry:
                 if (len(words) == 3):


### PR DESCRIPTION
This potentially fixes issue #113 
If num_iters is included in the rgt.input launch file:
```
test = app1 test1 5
```
then this is equivalent to
```
test = app1 test1
test = app1 test1
test = app1 test1
test = app1 test1
test = app1 test1
```
This may make life significantly easier for the user when trying to balance large loads of applications.