### PR TITLE
Added InfluxDefaults section to machine.ini

### DIFF
--- a/harness/libraries/config_file.py
+++ b/harness/libraries/config_file.py
@@ -9,6 +9,7 @@ class rgt_config_file:
     # These are the named sections in the config file.
     machine_section    = 'MachineDetails'
     repository_section = 'RepoDetails'
+    influx_section = 'InfluxDefaults'
     testshot_section   = 'TestshotDefaults'
 
     def __init__(self,
@@ -17,6 +18,7 @@ class rgt_config_file:
 
         self.__machine_vars = {}
         self.__repo_vars = {}
+        self.__influx_vars = {}
         self.__testshot_vars = {}
 
         if machinename != None:
@@ -53,6 +55,9 @@ class rgt_config_file:
             self.__repo_vars = master_cfg[rgt_config_file.repository_section]
             set_harness_environment(self.__repo_vars)
 
+            self.__influx_vars = master_cfg[rgt_config_file.influx_section]
+            set_harness_environment(self.__influx_vars)
+
             self.__testshot_vars = master_cfg[rgt_config_file.testshot_section]
             set_harness_environment(self.__testshot_vars)
         else:
@@ -66,6 +71,9 @@ class rgt_config_file:
 
     def get_repository_config(self):
         return self.__repo_vars
+
+    def get_influx_config(self):
+        return self.__influx_vars
 
     def get_testshot_config(self):
         return self.__testshot_vars


### PR DESCRIPTION
This section would allow the user to set default values for variables like RGT_INFLUX_URI, RGT_NODE_LOCATION_FILE, and other variables that a standard user wouldn't really need to know. This is basically just intended to be a mechanism to setting default values for these types of variables. The user could still override any/all of these.