### PR TITLE
36 check executable driver return status reports as 0 in log file

### DIFF
--- a/harness/bin/check_executable_driver.py
+++ b/harness/bin/check_executable_driver.py
@@ -120,8 +120,8 @@ def main():
         os.chdir(scriptsdir)
 
     check_command = "test_harness_driver.py --check -i " + testid
-    check_exit_value = os.system(check_command)
-    check_exit_value = os.WEXITSTATUS(check_exit_value)
+    check_exit_raw = os.system(check_command)
+    check_exit_value = os.WEXITSTATUS(check_exit_raw)
 
     message = f"The check command return status is {check_exit_value}."
     apptest.doInfoLogging(message)

--- a/harness/bin/check_executable_driver.py
+++ b/harness/bin/check_executable_driver.py
@@ -121,6 +121,7 @@ def main():
 
     check_command = "test_harness_driver.py --check -i " + testid
     check_exit_value = os.system(check_command)
+    check_exit_value = os.WEXITSTATUS(check_exit_value)
 
     message = f"The check command return status is {check_exit_value}."
     apptest.doInfoLogging(message)

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -521,7 +521,6 @@ def test_harness_driver(argv=None):
                           job_correctness)
 
     sys.exit(build_exit_value + submit_exit_value + run_exit_value + check_exit_value)
-   
 
 
 if __name__ == "__main__":

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -520,8 +520,9 @@ def test_harness_driver(argv=None):
         jstatus.log_event(status_file.StatusFile.EVENT_CHECK_END,
                           job_correctness)
 
-    sys.exit(build_exit_value + submit_exit_value + run_exit_value + check_exit_value)
+    return (build_exit_value + submit_exit_value + run_exit_value + check_exit_value)
 
 
 if __name__ == "__main__":
-    test_harness_driver()
+    exit_code = test_harness_driver()
+    exit(exit_code)

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -520,7 +520,8 @@ def test_harness_driver(argv=None):
         jstatus.log_event(status_file.StatusFile.EVENT_CHECK_END,
                           job_correctness)
 
-    return build_exit_value + submit_exit_value + run_exit_value + check_exit_value
+    sys.exit(build_exit_value + submit_exit_value + run_exit_value + check_exit_value)
+   
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Corrected issue by using `sys.exit()`. `os.WEXITSTATUS()` is needed to retrieve the actual exit code from the status returned by `os.system()`