### PR TITLE
Refactored file system path checks to occur after mode checkout would be performed

### DIFF
--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -156,32 +156,38 @@ class subtest(base_apptest, apptest_layout):
                 if test_checkout_lock:
                     test_checkout_lock.release()
 
-            elif harness_task == Harness.starttest:
-                message = "Start of starting test."
-                self.doInfoLogging(message)
+            else:
+                if not self.check_paths():
+                    self.logger.doErrorLogging(f"Aborting task {harness_task}. Could not find all required paths.")
+                    message = "Could not find all required paths on the file system for application {app1}, test {test1}.".format(app1=self.getNameOfApplication(),
+                                                                                                                                test1=self.getNameOfSubtest())
+                    raise ApptestFilePathError(message)
+                if harness_task == Harness.starttest:
+                    message = "Start of starting test."
+                    self.doInfoLogging(message)
 
-                self._start_test(launchid, stdout_stderr, separate_build_stdio=separate_build_stdio)
+                    self._start_test(launchid, stdout_stderr, separate_build_stdio=separate_build_stdio)
 
-                message = "End of starting test"
-                self.doInfoLogging(message)
+                    message = "End of starting test"
+                    self.doInfoLogging(message)
 
-            elif harness_task == Harness.stoptest:
-                self._stop_test()
+                elif harness_task == Harness.stoptest:
+                    self._stop_test()
 
-            elif harness_task == Harness.influx_log:
-                self._influx_log_mode()
+                elif harness_task == Harness.influx_log:
+                    self._influx_log_mode()
 
-            elif harness_task == Harness.displaystatus:
-                if test_display_lock:
-                    test_display_lock.acquire()
+                elif harness_task == Harness.displaystatus:
+                    if test_display_lock:
+                        test_display_lock.acquire()
 
-                self.display_status()
+                    self.display_status()
 
-                if test_display_lock:
-                    test_display_lock.release()
+                    if test_display_lock:
+                        test_display_lock.release()
 
-            elif harness_task == Harness.summarize_results:
-                self.generateReport()
+                elif harness_task == Harness.summarize_results:
+                    self.generateReport()
 
     def cloneRepository(self,my_repository,destination):
         #Get the current working directory.
@@ -1004,6 +1010,17 @@ class ApptestImproperInstantiationError(BaseApptestError):
                  args):
         self.__message = message
         self.__args = args
+        return
+
+    @property
+    def message(self):
+        return self.__message
+
+class ApptestFilePathError(BaseApptestError):
+    """Raised when the class subtest is run and required paths on the file system are missing."""
+    def __init__(self,
+                 message):
+        self.__message = message
         return
 
     @property

--- a/harness/libraries/regression_test.py
+++ b/harness/libraries/regression_test.py
@@ -252,16 +252,16 @@ class Harness:
                                                       logger = a_logger,
                                                       tag=self.__timestamp)
 
-                if subtest.check_paths():
-                    app_subtests[appname].append(subtest)
-                    self.__launched_tests += 1
-                else:
+                #if subtest.check_paths():
+                app_subtests[appname].append(subtest)
+                #self.__launched_tests += 1
+                #else:
                     # Then at least 1 required path (ie: source, scripts directories) does not exist
                     # Exact error messages are printed by check_paths
-                    a_logger.doWarningLogging(f"Skipping App={appname}, Test={testname}.")
+                    #a_logger.doWarningLogging(f"Skipping App={appname}, Test={testname}.")
                     # Log to both loggers
-                    self.__myLogger.doWarningLogging(f"Skipping App={appname}, Test={testname}.")
-                    self.__skipped_tests += 1
+                    #self.__myLogger.doWarningLogging(f"Skipping App={appname}, Test={testname}.")
+                    #self.__skipped_tests += 1
 
         return app_subtests
 
@@ -288,9 +288,11 @@ class Harness:
                 if my_future_exception:
                     message = "Application {} future exception:\n{}".format(appname, my_future_exception)
                     self.__myLogger.doCriticalLogging(message)
+                    self.__skipped_tests += 1
                 else:
                     message = "Application {} future is completed.".format(appname)
                     self.__myLogger.doInfoLogging(message)
+                    self.__launched_tests += 1
 
             message = "All applications completed futures. Yahoo!!"
             self.__myLogger.doInfoLogging(message)

--- a/harness/libraries/regression_test.py
+++ b/harness/libraries/regression_test.py
@@ -252,17 +252,7 @@ class Harness:
                                                       logger = a_logger,
                                                       tag=self.__timestamp)
 
-                #if subtest.check_paths():
                 app_subtests[appname].append(subtest)
-                #self.__launched_tests += 1
-                #else:
-                    # Then at least 1 required path (ie: source, scripts directories) does not exist
-                    # Exact error messages are printed by check_paths
-                    #a_logger.doWarningLogging(f"Skipping App={appname}, Test={testname}.")
-                    # Log to both loggers
-                    #self.__myLogger.doWarningLogging(f"Skipping App={appname}, Test={testname}.")
-                    #self.__skipped_tests += 1
-
         return app_subtests
 
     def __run_subtests_asynchronously(self):


### PR DESCRIPTION
Addresses #143 in an alternative way to PR #148 . Moves the path checks until after checkout mode would have been enforced, if it is specified.

Benefits of doing it this way include:
- if a test doesn't exist after checkout, then this catches that (ie, checkout pulled wrong branch)
- doesn't require mode checkout to be used to pass a conditional


Overall, it's just a more stable way to enforce file system paths.