### PR TITLE
Log level NOTSET is default and extremely verbose

### DIFF
--- a/harness/bin/log_binary_execution_time.py
+++ b/harness/bin/log_binary_execution_time.py
@@ -88,6 +88,7 @@ def main():
     apptest = SubtestFactory.make_subtest(name_of_application=app,
                                           name_of_subtest=test,
                                           local_path_to_tests=apps_root,
+                                          logger=a_logger,
                                           tag=unique_id)
     path_to_status_file = apptest.get_path_to_status_file()
     jstatus = StatusFileFactory.create(path_to_status_file=path_to_status_file, logger=a_logger)

--- a/harness/bin/runtests.py
+++ b/harness/bin/runtests.py
@@ -191,12 +191,12 @@ Specifying an unsupported loglevel will result in the harness aborting with an
 error.
 """
 
-DEFAULT_LOG_LEVEL=PERMITTED_LOG_LEVELS[0]
+DEFAULT_LOG_LEVEL="WARNING"
 """
 str: The default log level.
 
 If no loglevel option is specified on the command line, then default loglevel
-will be set to NOTSET.
+will be set to WARNING.
 """
 
 # This section pertains to the concurrency option. It

--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -95,8 +95,8 @@ def create_parser():
                            type=str,
                            help='Annotate test status with given harness launch id')
     my_parser.add_argument('--loglevel',
-                           default='CRITICAL',
-                           choices=['DEBUG', 'debug', 'INFO', 'info', 'WARNING', 'warning', 'ERROR', 'error', 'CRITICAL', 'critical'],
+                           default='WARNING',
+                           choices=['NOTSET', 'notset', 'DEBUG', 'debug', 'INFO', 'info', 'WARNING', 'warning', 'ERROR', 'error', 'CRITICAL', 'critical'],
                            help='Control the level of information printed to stdout.')
     my_parser.add_argument('-r', '--resubmit',
                            help='Have the application test batch script resubmit itself, optionally for a total submission count of N. Leave off N for infinite submissions.',

--- a/harness/machine_types/base_machine.py
+++ b/harness/machine_types/base_machine.py
@@ -452,11 +452,13 @@ class BaseMachine(metaclass=ABCMeta):
 
         path_to_source = self.apptest.get_path_to_source()
         message = f"{messloc} Path to Source: {path_to_source}"
-        self.logger.doInfoLogging(message)
+        # Send message at error threshold so that it's nearly always seen
+        self.logger.doErrorLogging(message)
 
         path_to_build_directory = self.apptest.get_path_to_workspace_build()
         message = f"{messloc} Path to build directory: {path_to_build_directory}"
-        self.logger.doInfoLogging(message)
+        # Send message at error threshold so that it's nearly always seen
+        self.logger.doErrorLogging(message)
 
         shutil.copytree(src=path_to_source,
                         dst=path_to_build_directory,

--- a/harness/machine_types/base_machine.py
+++ b/harness/machine_types/base_machine.py
@@ -451,14 +451,12 @@ class BaseMachine(metaclass=ABCMeta):
         messloc = "In function {functionname}:".format(functionname=self._name_of_current_function()) 
 
         path_to_source = self.apptest.get_path_to_source()
-        message = f"{messloc} Path to Source: {path_to_source}"
-        # Send message at error threshold so that it's nearly always seen
-        self.logger.doErrorLogging(message)
+        # Use Error threshold to show this message all the time
+        self.logger.doErrorLogging(f"Path to Source: {path_to_source}")
 
         path_to_build_directory = self.apptest.get_path_to_workspace_build()
-        message = f"{messloc} Path to build directory: {path_to_build_directory}"
-        # Send message at error threshold so that it's nearly always seen
-        self.logger.doErrorLogging(message)
+        # Use Error threshold to show this message all the time
+        self.logger.doErrorLogging(f"Path to Build: {path_to_build_directory}")
 
         shutil.copytree(src=path_to_source,
                         dst=path_to_build_directory,


### PR DESCRIPTION
Key changes:
- Changed default from NOTSET to WARNING for both runtests.py and test_harness_driver.py (will usually inherit from runtests.py)
- Added NOTSET as a valid option in test_harness_driver.py.

Fixes #156 