### PR TITLE
Implemented return codes in apptest.doTasks

### DIFF
--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -1041,7 +1041,7 @@ def do_application_tasks(launch_id,
                          stdout_stderr,
                          separate_build_stdio=False):
     # Returns [#Passed,#Failed]
-    ret = [0,0]
+    ret = [0, 0, []]
     for app_test in app_test_list:
         print(f"Starting tasks for Application.Test: {app_test.getNameOfApplication()}.{app_test.getNameOfSubtest()}: {tasks}")
         # Non-zero exit status is failure
@@ -1050,6 +1050,7 @@ def do_application_tasks(launch_id,
                          stdout_stderr=stdout_stderr,
                          separate_build_stdio=separate_build_stdio):
             ret[1] += 1
+            ret[2].append(f"{app_test.getNameOfApplication()}.{app_test.getNameOfSubtest()}")
         else:
             ret[0] += 1
     return ret

--- a/harness/libraries/apptest.py
+++ b/harness/libraries/apptest.py
@@ -1024,17 +1024,6 @@ class ApptestImproperInstantiationError(BaseApptestError):
     def message(self):
         return self.__message
 
-class ApptestFilePathError(BaseApptestError):
-    """Raised when the class subtest is run and required paths on the file system are missing."""
-    def __init__(self,
-                 message):
-        self.__message = message
-        return
-
-    @property
-    def message(self):
-        return self.__message
-
 def do_application_tasks(launch_id,
                          app_test_list,
                          tasks,

--- a/harness/libraries/regression_test.py
+++ b/harness/libraries/regression_test.py
@@ -80,7 +80,8 @@ class Harness:
             testshot_str = testshot_cfg[testshot_key]
         self.__launch_id = f'{testshot_str}/{user_str}@{time_str}'
         self.__launched_tests = 0
-        self.__skipped_tests = 0
+        self.__failed_tests = 0
+        self.__failed_test_list = []
 
         # Define a logger that streams to file.
         logger_name=Harness.LOGGER_NAME
@@ -286,12 +287,18 @@ class Harness:
 
                 subtest_result = my_future.result()
                 self.__launched_tests += subtest_result[0]
-                self.__skipped_tests += subtest_result[1]
+                self.__failed_tests += subtest_result[1]
+                if self.__failed_tests:
+                    self.__failed_test_list.extend(subtest_result[2])
 
             message = "All applications completed futures. Yahoo!!"
             self.__myLogger.doInfoLogging(message)
             # For the moment, hard-code this as a print statement.
-            print(f"Launched {self.__launched_tests} tests, skipped {self.__skipped_tests} tests.")
+            print(f"Launched {self.__launched_tests} tests, failed to launch {self.__failed_tests} tests.")
+            if self.__failed_tests:
+                print("Failed tests:")
+                for t in self.__failed_test_list:
+                    print(f"\t{t}")
 
         return
 

--- a/harness/libraries/regression_test.py
+++ b/harness/libraries/regression_test.py
@@ -280,11 +280,13 @@ class Harness:
                 if my_future_exception:
                     message = "Application {} future exception:\n{}".format(appname, my_future_exception)
                     self.__myLogger.doCriticalLogging(message)
-                    self.__skipped_tests += 1
                 else:
                     message = "Application {} future is completed.".format(appname)
                     self.__myLogger.doInfoLogging(message)
-                    self.__launched_tests += 1
+
+                subtest_result = my_future.result()
+                self.__launched_tests += subtest_result[0]
+                self.__skipped_tests += subtest_result[1]
 
             message = "All applications completed futures. Yahoo!!"
             self.__myLogger.doInfoLogging(message)


### PR DESCRIPTION
Fixes #158 

Instead of using exceptions and sys.exit, returning non-zero aborts the current subtest while allowing others to attempt to continue. This would be useful in cases where there's a typo in a test name, a build failure for a specific test, or a missing file for a specific test.

One enhancement that could be made is printing the names of the failed tests.