### PR TITLE
Added general exception to catch errors when interpreting config file

### DIFF
--- a/harness/machine_types/rgt_test.py
+++ b/harness/machine_types/rgt_test.py
@@ -439,10 +439,13 @@ class RgtTest():
                 raise ErrorRgtTestInputFileNotFound(error_message)
         except ErrorRgtParameterReconcile as err:
             self.__logger.doCriticalLogging(err.message)
-            sys.exit(err.message)
+            exit(err.message)
         except ErrorRgtTestInputFileNotFound as err:
             self.__logger.doCriticalLogging(err.message)
-            sys.exit(err.message)
+            exit(err.message)
+        except Exception as e:
+            self.__logger.doCriticalLogging(e)
+            exit(1)
 
     # Private methods
 

--- a/harness/machine_types/rgt_test.py
+++ b/harness/machine_types/rgt_test.py
@@ -437,14 +437,8 @@ class RgtTest():
             else:
                 error_message = "Test input file {} not found".format(self.test_input_filename)
                 raise ErrorRgtTestInputFileNotFound(error_message)
-        except ErrorRgtParameterReconcile as err:
+        except Exception as err:
             self.__logger.doCriticalLogging(err.message)
-            exit(err.message)
-        except ErrorRgtTestInputFileNotFound as err:
-            self.__logger.doCriticalLogging(err.message)
-            exit(err.message)
-        except Exception as e:
-            self.__logger.doCriticalLogging(e)
             exit(1)
 
     # Private methods


### PR DESCRIPTION
Fixes #169 and #135 

Example output now:
```
Using launch id: borg_test/hagertnl@2024-05-16T11:54:36.06
Generated test unique id: 1715874876.2979047
Creating machine borg: Type = linux_x86_64 ; Scheduler = slurm ; Job launcher = srun
Creating scheduler
Creating jobLauncher
Bad value substitution: option 'abc' in section 'EnvVars' contains an interpolation key 'nodes' which is not a valid option name. Raw value: '%(nodes)s'
In function subtest._start_test we have a critical error.
The command 'test_harness_driver.py -r -l borg_test/hagertnl@2024-05-16T11:54:36.06 --loglevel WARNING' has exited with a failure.
The exit return value is 1
.
Launched 0 tests, failed to launch 1 tests.
Failed tests:
	harness_unit_tests.test_inp_invalid_ref
```

This will still halt and not launch other tests that might've been queued for behind this test, but that is because there's just not the infrastructure in place to return exit codes and have things cleanly exit yet.