### PR TITLE
Fixing SHLVL too high error for Slurm, issue 181

### DIFF
--- a/harness/machine_types/slurm.py
+++ b/harness/machine_types/slurm.py
@@ -46,6 +46,11 @@ class SLURM(BaseScheduler):
         elif 'RGT_PROJECT_ID' in os.environ:
             qargs += " -A " + os.environ.get('RGT_PROJECT_ID')
 
+        # Fix issue #181 -- reset SHLVL to 1 every time we submit
+        # Since this is not an interactive session, SHLVL is functionally useless
+        if 'SHLVL' in os.environ:
+            os.environ['SHLVL'] = "1"
+
         qcommand = self.__submitCmd + " " + qargs + " " + batchfilename
         print(qcommand)
 


### PR DESCRIPTION
Closes #181 

This issue likely is not an issue in PBS, as PBS appears to primarily reset the shell environment in compute jobs.