### PR TITLE
Fix #210, return status integer overflow

### DIFF
--- a/harness/bin/test_harness_driver.py
+++ b/harness/bin/test_harness_driver.py
@@ -170,7 +170,6 @@ def auto_generated_scripts(harness_config,
             a_logger.doCriticalLogging(message)
         finally:
             jstatus.log_event(status_file.StatusFile.EVENT_BUILD_END, build_exit_value)
-
     #-----------------------------------------------------
     # In this section we run the the binary.             -
     #                                                    -
@@ -182,7 +181,6 @@ def auto_generated_scripts(harness_config,
     job_id = "0"
     submit_exit_value = 0
     if actions['submit'] and (build_exit_value != 0):
-        submit_exit_value = 1
         message = f"No submit action due to prior failed build."
         a_logger.doCriticalLogging(message)
     elif actions['submit'] and (build_exit_value == 0):


### PR DESCRIPTION
remove extraneous submit status value. When combined with a build output of 255, this was causing an integer overflow back to 0