### PR TITLE
Added support for `use_batch_template`, fixed excessive Kafka warnings

### DIFF
--- a/harness/libraries/layout_of_apps_directory.py
+++ b/harness/libraries/layout_of_apps_directory.py
@@ -311,6 +311,7 @@ class apptest_layout:
             try_symlink(os.environ['RGT_REUSE_BUILD_FROM'], os.path.join(ws_dir, apptest_layout.test_build_dirname))
         try_symlink(build_dir, os.path.join(ra_dir, apptest_layout.test_build_dirname))
         try_symlink(run_dir, os.path.join(ra_dir, apptest_layout.test_run_dirname))
+        try_symlink(st_dir, os.path.join(ra_dir, apptest_layout.test_status_dirname))
 
     def create_test_workspace(self, path_to_workspace):
         """

--- a/harness/libraries/rgt_database_loggers/rgt_database_logger.py
+++ b/harness/libraries/rgt_database_loggers/rgt_database_logger.py
@@ -324,21 +324,24 @@ class RgtDatabaseLogger:
         # Load InfluxDB now, because we use templated env-vars
         influxdb_loaded = False
         kafka_loaded = False
-        try:
-            # Can fail for a number of reasons. Mostly if `requests` module is not installed
-            from libraries.rgt_database_loggers.db_backends.rgt_influxdb import InfluxDBLogger
-            influxdb_loaded = True
-        except ImportError as e:
-            self.logger.doErrorLogging(f"Failed to import InfluxDB backend: {e}")
-            pass
 
-        try:
-            # Can fail for a number of reasons. Mostly if `requests` module is not installed
-            from libraries.rgt_database_loggers.db_backends.rgt_kafka import KafkaLogger
-            kafka_loaded = True
-        except ImportError as e:
-            self.logger.doErrorLogging(f"Failed to import Kafka backend: {e}")
-            pass
+        if any(k.startswith('RGT_INFLUX') for k in os.environ):
+            try:
+                # Can fail for a number of reasons. Mostly if `requests` module is not installed
+                from libraries.rgt_database_loggers.db_backends.rgt_influxdb import InfluxDBLogger
+                influxdb_loaded = True
+            except ImportError as e:
+                self.logger.doErrorLogging(f"Failed to import InfluxDB backend: {e}")
+                pass
+
+        if any(k.startswith('RGT_KAFKA') for k in os.environ):
+            try:
+                # Can fail for a number of reasons. Mostly if `requests` module is not installed
+                from libraries.rgt_database_loggers.db_backends.rgt_kafka import KafkaLogger
+                kafka_loaded = True
+            except ImportError as e:
+                self.logger.doErrorLogging(f"Failed to import Kafka backend: {e}")
+                pass
 
         if influxdb_loaded and not 'influxdb' in self.disabled_backends \
                 and ( InfluxDBLogger.kw['uri'] in os.environ and InfluxDBLogger.kw['token'] in os.environ ):

--- a/harness/machine_types/linux_utilities.py
+++ b/harness/machine_types/linux_utilities.py
@@ -71,7 +71,7 @@ def make_batch_script_for_linux(a_machine):
 
     if str(a_machine.test_config.get_use_batch_template()) == '0':
         a_machine.logger.doInfoLogging(f"use_batch_template = 0 is set in test configuration file, skipping batch script generation.")
-        return
+        return True
 
     # Log that our execution location.
     message = "Making batch script for {} using file {}.".format(a_machine.machine_name,a_machine.get_scheduler_template_file_name())

--- a/harness/machine_types/linux_utilities.py
+++ b/harness/machine_types/linux_utilities.py
@@ -69,6 +69,10 @@ def make_batch_script_for_linux(a_machine):
     frame = inspect.currentframe()
     function_name = inspect.getframeinfo(frame).function
 
+    if str(a_machine.test_config.get_use_batch_template()) == '0':
+        a_machine.logger.doInfoLogging(f"use_batch_template = 0 is set in test configuration file, skipping batch script generation.")
+        return
+
     # Log that our execution location.
     message = "Making batch script for {} using file {}.".format(a_machine.machine_name,a_machine.get_scheduler_template_file_name())
     a_machine.logger.doInfoLogging(message)
@@ -433,7 +437,6 @@ def submit_batch_script(a_machine, new_env):
     for e in env_vars:
         v = env_vars[e]
         eu = e.upper()
-        #print("Setting env var", eu, "=", v)
         os.putenv(eu, v)
         message += f"Set batch environment variable {eu}={v}\n"
     if new_env:

--- a/harness/machine_types/lsf.py
+++ b/harness/machine_types/lsf.py
@@ -47,7 +47,12 @@ class LSF(BaseScheduler):
         elif 'RGT_PROJECT_ID' in os.environ:
             qargs += " -P " + os.environ.get('RGT_PROJECT_ID')
 
-        qcommand = self.__submitCmd + " " + qargs + " " + batchfilename
+        qcommand = self.__submitCmd + " " + qargs
+
+        if 'RGT_LSF_SUBMIT_AS_STDIN' in os.environ and \
+                str(os.environ['RGT_LSF_SUBMIT_AS_STDIN']) == '0':
+            qcommand += " " + batchfilename
+
         self.__logger.doInfoLogging(f"{qcommand}")
 
         args = shlex.split(qcommand)

--- a/harness/machine_types/lsf.py
+++ b/harness/machine_types/lsf.py
@@ -57,13 +57,14 @@ class LSF(BaseScheduler):
         submit_stdout = open(temp_stdout,"w")
         submit_stderr = open(temp_stderr,"w")
 
-        # We no longer need 'bsub <' since we are using the OLCF bsub
-        #jobfileobj = open(batchfilename,"r")
-        #p = subprocess.Popen(args,stdout=submit_stdout,stderr=submit_stderr,stdin=jobfileobj)
-        #jobfileobj.close()
-
-        p = subprocess.Popen(args,stdout=submit_stdout,stderr=submit_stderr)
-        p.wait()
+        if 'RGT_LSF_SUBMIT_AS_STDIN' in os.environ and \
+                str(os.environ['RGT_LSF_SUBMIT_AS_STDIN']) == '0':
+            p = subprocess.Popen(args,stdout=submit_stdout,stderr=submit_stderr)
+            p.wait()
+        else:
+            with open(batchfilename,"r") as jobfileobj:
+                p = subprocess.Popen(args,stdout=submit_stdout,stderr=submit_stderr,stdin=jobfileobj)
+                p.wait()
 
         submit_stdout.close()
         submit_stderr.close()

--- a/harness/machine_types/rgt_test.py
+++ b/harness/machine_types/rgt_test.py
@@ -147,6 +147,7 @@ class RgtTest():
             "report_cmd" :         {"required": True, "type": str},
             "resubmit" :           {"required": False, "type": int, "valid": lambda x: True if (int(x) == 1 or int(x) == 0) else False},
             "total_processes" :    {"required": False, "type": int, "valid": lambda x: True if (int(x) >= 1) else False},
+            "use_batch_template":  {"required": False, "type": int, "valid": lambda x: True if (int(x) == 1 or int(x) == 0) else False},
             "walltime" :           {"required": True, "type": str},
         }
 
@@ -392,6 +393,9 @@ class RgtTest():
 
     def get_project(self):
         return self._get_builtin_param("project_id")
+
+    def get_use_batch_template(self):
+        return self._get_builtin_param("use_batch_template")
 
     def get_walltime(self):
         return self._get_builtin_param("walltime")

--- a/harness/utilities/rgt_archive_tests.py
+++ b/harness/utilities/rgt_archive_tests.py
@@ -260,9 +260,16 @@ def archive_test(apptest, test_id):
 
     # Archive -- use shutil.copytree to copy the current Run_Archive with sym-links for build_directory and workdir
     shutil.copytree(test_run_archive, test_archive_dir, symlinks=True)
+
     # remove build_directory and workdir sym-links in Archive
     os.unlink(os.path.join(test_archive_dir, apptest_layout.test_run_dirname))
     os.unlink(os.path.join(test_archive_dir, apptest_layout.test_build_dirname))
+
+    # if Status sym-link exists, then un-link, will copy later
+    if os.path.exists(os.path.join(test_archive_dir, apptest_layout.test_status_dirname)):
+        os.unlink(os.path.join(test_archive_dir, apptest_layout.test_status_dirname))
+    shutil.copytree(test_status, os.path.join(test_archive_dir, apptest_layout.test_status_dirname), symlinks=True)
+
     # copy the real build_directory and workdir directories if they exist & if flags are right
     test_failed = False
     if (not test_info['event_value'] == '0') and (not test_info['event_name'] == 'job_queued') and (not test_info['event_name'] == 'submit_end'):


### PR DESCRIPTION
Implement #261 , and also add a simple conditional to gate loading Kafka & InfluxDB.

Tested using this simple test case:
```
$ tree .
.
├── Scripts
│   └── rgt_test_input.ini
│   └── check.sh -- empty, but with executable permissions
└── Source
    └── build_byo_batch_script.sh

2 directories, 2 files

$ cat Scripts/rgt_test_input.ini
[Replacements]
job_name = test_byo_batch_script
nodes = 1
total_processes = 1
walltime = 1
batch_filename = run.sh
build_cmd = ./build_byo_batch_script.sh
check_cmd = ./check.sh
report_cmd = /usr/bin/echo
resubmit = 1
use_batch_template = 0
[EnvVars]

$ cat Source/build_byo_batch_script.sh
#!/bin/bash

# Create the batch script:
echo "#!/bin/bash
#SBATCH -A ${RGT_PROJECT_ID}
#SBATCH -N 1
#SBATCH -J myjob
#SBATCH -t 2

export HARNESS_ID=$(basename $(dirname ${PWD}))
export RESULTS_DIR=${RGT_TEST_RUNARCHIVE_DIR}
export WORK_DIR=${RGT_TEST_WORK_DIR}
export BUILD_DIR=${PWD}
export SCRIPTS_DIR="${RGT_TEST_SCRIPTS_DIR}"

# Make the working scratch space directory.
if [ ! -e \$WORK_DIR ]
then
    mkdir -p \$WORK_DIR
fi

# Change directory to the working directory.
cd \$WORK_DIR
env &> job.environ
scontrol show hostnames > job.nodes
log_binary_execution_time.py --scriptsdir \$SCRIPTS_DIR --uniqueid \$HARNESS_ID --mode start

# Sleep for 5 seconds
sleep 5

log_binary_execution_time.py --scriptsdir \$SCRIPTS_DIR --uniqueid \$HARNESS_ID --mode final
# Ensure we return to the starting directory.
cd \$SCRIPTS_DIR
# Copy the output and results back to the \$RESULTS_DIR
cp -rf \$WORK_DIR/* \$RESULTS_DIR
# Check the final results.
check_executable_driver.py -p \$RESULTS_DIR -i \$HARNESS_ID

# Resubmit if needed
case __resubmit__ in
    0)
       echo "No resubmit";;
    1)
       test_harness_driver.py -r __max_submissions__ ;;
esac
" > ${RGT_TEST_RUNARCHIVE_DIR}/run.sh
```